### PR TITLE
【sign-preprocessor】関数複数呼び出し対応

### DIFF
--- a/et-key/sign-preprocessor/compiler/sign-stack-compiler.js
+++ b/et-key/sign-preprocessor/compiler/sign-stack-compiler.js
@@ -86,7 +86,7 @@ class SignStackCompiler {
         this.dataStack = [];
         this.outputQueue = [];
         this.operandInfo = [];
-        
+
         // 関数適用をコンパイル
         this.compileFunctionApplication(stmt);
         this.generateStackMachineCode();
@@ -374,6 +374,9 @@ class SignStackCompiler {
     generateFunctionCall(functionName, argCount) {
         this.assembly.push(`# 関数呼び出し: ${functionName} (引数${argCount}個)`);
 
+        // x8レジスタ保護（ファイルディスクリプタ保護）
+        this.assembly.push(`    mov x16, x8               // x8保存`)
+
         // 引数をスタックから取り出し（後入れ先出しなので逆順）
         const args = [];
         for (let i = 0; i < Math.min(argCount, 4); i++) {
@@ -405,11 +408,21 @@ class SignStackCompiler {
         this.assembly.push(`# call function`);
         this.assembly.push(`    bl ${functionName}`);
 
+        // x8レジスタ復元
+        this.assembly.push(`    mov x8, x16               // x8復元`);
+
         // 戻り値はx0に入る（これをデータスタックに保存）
         const resultReg = this.getNextDataReg();
         this.assembly.push(`# store return value`);
         this.assembly.push(`    mov ${resultReg}, x0`);
         this.dataStack.push(resultReg);
+
+        // operandInfo を正しく更新
+        this.operandInfo.push({
+            type: 'variable',
+            value: `${functionName}_result`,
+            valueType: 'string' // test関数は文字列を返すと仮定
+        });
     }
 
     // Output操作生成（新規実装）
@@ -461,6 +474,7 @@ class SignStackCompiler {
         // Sign言語仕様準拠の戻り値処理
         const resultReg = this.getNextDataReg();
         this.assembly.push(`    csel ${resultReg}, x0, xzr, ge // success: bytes written, fail: Unit`);
+        this.assembly.push(`    // Note: x8 may be modified by syscall but will be reset for next output`);
         this.dataStack.push(resultReg);
         this.operandInfo.push({ type: 'computed', value: 'output_result' });
     }

--- a/et-key/sign-preprocessor/example/test-input_tmp.sn
+++ b/et-key/sign-preprocessor/example/test-input_tmp.sn
@@ -1,10 +1,25 @@
 ` ###############################################
 ` # テスト用print関数
 ` ###############################################
+` 関数呼び出し・直接出力
+ret_test : str ? str
+0x1 # `string `
+0x1 # (ret_test `test OK`)
+
+` print関数化（改行は外付）
 print : str ?
 	0x1 # str
 
 print ( `hello` + `\n` )
+print ( `world` + `\n` )
+
+
+` println関数化（改行含む）※実装途中
+println : str ?
+	0x1 # ( str + `\n` )
+	
+println `Hello Wolrd!`
+
 
 
 


### PR DESCRIPTION
```
` print関数化（改行は外付）
print : str ?
	0x1 # str

print ( `hello` + `\n` )
print ( `world` + `\n` )
```
のように関数複数回で動作するように修正