### PR TITLE
update : Documents_en-us

### DIFF
--- a/documents/en-us/Sign_reference_en-us.md
+++ b/documents/en-us/Sign_reference_en-us.md
@@ -54,14 +54,15 @@ The following summarizes its features:
 * There are no reserved words used for control
 * There are no control statements; all calculations always return an answer
 * Block syntax is formed by indentation using tab characters
-* Spaces are considered as operators, but in implementation, they can be treated as delimiters for literals
-* Infix operators generally require spaces before and after them, but when an expression can be interpreted as an infix operator, spaces are automatically inserted
+* Spaces are considered as operators for examination, but may be treated as delimiters for literals
+* When function composition is performed by spaces, it has left identity
 * Prefix and postfix operators must not have spaces between them and their target literals
+* Infix operators generally require spaces before and after them, but when they can be interpreted as infix operators, spaces are automatically inserted
 * Lines with only literals without meaning are never executed
 * Code files have local scope, and scopes are not contaminated unless import or export is used
-* empty lists, and unexecuted lambda terms are false. Everything else is true, so the boolean type is never explicitly specified
-* All logical operations are short-circuit evaluated
-* Bit operations exist for optimization. Therefore, there are no operators or functions that directly represent bit operations
+* Empty lists and unevaluated lambda terms are false. Everything else is true, so the boolean type is never explicitly specified
+* Logical operations are basically short-circuit evaluated
+* Bit operations exist for optimization. Therefore, operators or functions that directly represent bit operations are subject to additional implementation
 * Lists of arguments passed to functions are lists
 * All objects to be calculated are lists
 * The Sign source code itself is also a list
@@ -218,23 +219,28 @@ Normally used in the sense of Null, and also used in the sense of false. Details
 # Operators []({#operators})
 
 Operators are of the following types, and since explaining from the lower priority areas is considered to speak of derivation by basic functions, they are explained in order from the low priority areas.
-However, the grandchild level in the bullet points has the same operator precedence.
-Infix operators are principally left identities and need spaces at both ends. (Those that should be noted as right identities have a * mark at the back.)
-However, most operators can be properly inserted with spaces through input completion. (Those where input completion space insertion does not work have an ✕ mark at the back.)
+However, **the grandchild level in the bullet points has the same operator precedence**.
+Infix operators are principally left identities and need spaces at both ends.
+(Those that should be noted as right identities have right added at the back.)
+
+Most operators can have spaces properly inserted before and after them through input completion functionality.
+(Those where input completion space insertion does not work have an ✕ mark at the back.)
+
+(During syntax parsing, operators that can be understood by simple type combinations alone have a ＼ mark attached.)
 
 * Export area
   * `#`	(export prefix operator)
 
 * Definition, output area
-  * `:`	(define infix operator *)　
-  * `#`	(output infix operator *)
+  * `:`	(define infix operator right)　
+  * `#`	(output infix operator right)
   
 
 * Construction area
-  * ` `	(coproduct infix operator)
-  * `?`	(lambda construction infix operator *)
-  * `,`	(product infix operator *)
-  * `~`	(range list construction infix operator)
+  * ` `	(coproduct infix operator　＼)
+  * `?`	(lambda construction infix operator right)
+  * `,`	(product infix operator right)
+  * `~`	(range list construction infix operator　✕)
   * `~`	(continuous list construction prefix operator)
 
 * Logical area
@@ -267,7 +273,7 @@ However, most operators can be properly inserted with spaces through input compl
     * `%`	(modulus infix operator)
 
   * Exponentiation
-    * `^`	(power infix operator *)
+    * `^`	(power infix operator right)
 
   * Factorial
     * `!`	(factorial postfix operator)
@@ -276,7 +282,7 @@ However, most operators can be properly inserted with spaces through input compl
   * `~`	(expansion postfix operator)
   * `$`	(address acquisition prefix operator)
   * `'`	(get infix operator)
-  * `@`	(get infix operator *)
+  * `@`	(get infix operator right　✕)
   * `
   `	(evaluation postfix operator)
 
@@ -374,6 +380,7 @@ sign : `Sign!`
 hello : `Hello ` 
 hello sign = `Hello Sign!`
 ```
+
 `[Function] [Expression]`
 
 `[Identifier → Function] [Expression]`
@@ -510,11 +517,13 @@ F [* 2] , 1 , 2 , 3
 ## `~`	(range list construction infix operator) []({#-tilde(range-list-construction-infix-operator)})
 
 Note that `~` has different meanings as prefix, postfix, and infix!
-
-The `~` infix operator can abstractly handle ranges, such as range specification. The type is as follows:
+The `~` infix operator must be surrounded by parentheses before and after!
+The `~` infix operator can handle ranges. The type is as follows:
 
 `[Character] ~ [Character]`
 `[Number] ~ [Number]`
+`[Adress] ~ [Adress]`
+
 
 Be careful as the range list construction operator has low precedence.
 It's also easy to use when getting a specific range from a list.
@@ -524,6 +533,14 @@ It's also easy to use when getting a specific range from a list.
 [1 ~ 10]
 [* 2,] [1 ~ 10] ' [3 ~ 5] = 8 , 10 , 12
 [\a ~ \z]
+```
+
+Note that range specification with 3 terms is also possible, where the range specification uses the next value - initial value as the step value.
+
+（例）
+```javascript
+[2 ~ 4 ~ 10] = 2 , 4 , 6 , 8 , 10
+[1 ~ 3 ~ 10] = 1 , 3 , 5 , 7 , 9
 ```
 
 ## `~`	(continuous list construction prefix operator) []({#-tilde(continuous-list-construction-prefix-operator)})
@@ -829,8 +846,6 @@ The block construction prefix operator is the construction of blocks by indentat
 ```
 The following inline block construction with parentheses has the same meaning, so it's omitted.
 
-Here's the English translation:
-
 # About Metaprogramming
 
 In Sign, functionality for metaprogramming is provided.
@@ -841,6 +856,7 @@ Reserved words exist within declarations.
 ## About Reserved Words in Metaprogramming Declarations
 The following reserved words exist for defining operators.
 These reserved words are only valid within metaprogramming declarations and cannot be used in normal code.
+
 
 * `Prefix`		(prefix operator)
 * `Infix`		(infix operator without identity element)
@@ -891,7 +907,7 @@ Reason: Because it becomes a contributing factor to excessive abstraction (goes 
 For symbols enclosed in `"`, Sign can describe such behavior.
 Also, since macros can output variable code that should be executed at that time, use them carefully.
 
-The following is an example of overloading & as an operator for bit operations.
+The following is an example of defining && as an operator for bit operations.
 
 ```
 `Set the filename as bit.sn.
@@ -900,9 +916,7 @@ The following is an example of overloading & as an operator for bit operations.
 `The implementation definition of the operator is described in Sign language or assembly language.
 
 "
-	InfixL $ && '
-
-	&& : x y ?
+	infixL && : x y ?
 		unsafe@
 			r0 # x
 			r1 # y

--- a/documents/en-us/example.en-us.sn
+++ b/documents/en-us/example.en-us.sn
@@ -32,6 +32,7 @@ unit : none : []
 none : []
 unit : []
 
+
 `Comparison operations have shorthands.`
 
 `[[x = y & y] = z] & y`
@@ -42,11 +43,13 @@ x = y = z
 
 1 <= x <= 9
 
+
 `Lambda term definition method`
 `The basis of lambda terms uses '?'.`
 `Functions without assignment must be enclosed in parentheses.`
 
 [x y ? x ^ 2 + 2 * x * y + y ^ 2]
+
 
 `Factoring the above shows that this expression is equivalent to the following.`
 `By reinterpreting parentheses purely as the start of a block definition, expression precedence can be expressed.`
@@ -65,21 +68,25 @@ x = y = z
 
 `...it would be.`
 
+
 `If you don't want function application or composition, you can append a comma directly after the function to create a Cartesian product.`
 `Alternatively, you can use the '$' prefix operator before the function to obtain a temporary address.`
 
 [+ 2] 2 = 4
 [+ 2], 2 = [+ 2], 2
 
+
 `Example of passing a function as a Cartesian product`
 
 Filter : f x ~y ? f x , Filter f y~
 Filter [> 0], [-2 ~ 3]
 
+
 `Example in the case of a function pointer`
 
 Filter : f x ~y ? @f x , Filter f y~
 Filter $[> 0] [-2 ~ 3]
+
 
 `The very last argument of a function can also be written before the function.`
 
@@ -87,6 +94,7 @@ result2 : [-] 3 1
 add : [+]
 exp : [^]
 id : x ? x
+
 
 `Function evaluation has lower precedence than lambda definition.`
 `Function composition is a left identity, but normal function execution can be written as a right identity.`
@@ -102,6 +110,7 @@ id : x ? x
 [1 2 3] ' 0 = 1
 [1, 2, 3] ' 0 = 1
 
+
 `The following functions as a function that returns the tail.`
 
 [_ ~y ? y] 1 2 3 = 2 3
@@ -109,6 +118,7 @@ id : x ? x
 
 [1 2 3] ' 1~ = 2 3
 [1, 2, 3] ' 1~ = 2 3
+
 
 `Arguments passed to higher-order functions must be explicitly separated by Cartesian product to determine whether they are evaluated or not.`
 
@@ -138,12 +148,12 @@ id : x ? x
 ] 3
 
 `Constructor-like description.`
-`Dynamic key names can also be assigned; in such cases, to force extraction of values assigned to variables or arguments, use the postfix '~'.`
+`Dynamic key names can also be assigned; in such cases, to force extraction of values assigned to variables or arguments, use prefix @ and prefix $.`
 
 Person : name age etc x ?
 	name
 	age
-	etc~ : x
+	@$etc : x
 
 john : Person `john` 18 `Like` `Sushi`
 
@@ -155,6 +165,7 @@ john ' name = john ' `name`
 `If 'otherwise' is not specified and 'otherwise' is matched, it returns the passed value as is, following the identity law.`
 
 [> 3 : [+ 3]] 3 4 = 4
+
 
 `Data class-like description`
 
@@ -179,12 +190,14 @@ lightningStaff : Item
 	[' ThunderBolt]
 	[' HP] [- 40]
 
+
 `The so-called 'let ~ in' is also written as follows.`
 
 myValue :
 	3
 	[+ 4]
 	[* 2]
+
 
 `List definitions are generally comma-separated.`
 `"," in English denotes a "strong separator" or "Cartesian product."`
@@ -219,24 +232,29 @@ myPairs ' [1 ~ 3] = 2 3 4
 
 [> 2,] myPairs = 3 4 5
 
+
 `This is a coproduct (array concatenation).`
 
 r: [1 2] [3 4]
+
 
 `This is a Cartesian product (2D array).`
 
 s: [1 2],[3 4]
 
+
 `Dictionary type`
 `However, opening and closing parentheses must always be paired.`
 
 myGreet:
-	greet:
+	greet: 
 		hello: `hello,`
 		welcome: `welcome,`
 	world : ` world`
 
+
 myGreet ' greet ' hello = `hello,`
+
 
 `By using block scope, 'get' can be directly written within the block scope.`
 `This block syntax, of course, also returns a value upon completion of the operation.`
@@ -248,6 +266,7 @@ myGreet
 	'world
 = `welcome, world`
 
+
 `Values can be modified.`
 
 myGreet
@@ -255,8 +274,10 @@ myGreet
 		'welcome : `welcome to our `
 	'world : `metaverse!`
 
+
 `By inferring only primitive types, the actual type problem is designed to be solved.`
 `All given names are definitions, and as they are self-evident types, the name *is* the type.`
+
 
 `The '~' operator can only expand match_case, which mimics a dictionary type, onto the target scope.`
 `If prefixed, it takes precedence over other terms; if postfixed, other terms take precedence.`
@@ -268,6 +289,7 @@ myGreet
 
 y = 1
 
+
 `The '@' postfix operator is for import. File names can be specified, and paths are also allowed.`
 `If match_case can be treated as a dictionary type, the '~' operator can expand it to the scope above, so '@~' also allows imports usable within the file.`
 
@@ -277,6 +299,7 @@ io@
 `Since this is not a file-scoped import, the line below will return a "Say is not defined" error.`
 
 say Hello World
+
 
 `Expand to file scope for use.`
 
@@ -298,7 +321,7 @@ io@~
 M: \M
 
 My: M \y\ \D\o\m\e\s\t\i\c
-My = M \y \ \D \o \m \e \s \t \i \c = `My Domestic`
+My = M \y \  \D \o \m \e \s \t \i \c = `My Domestic`
 
 	`Hello ` `World!` = `Hello World!`
 	`Hello` \ `World!` = `Hello World!`
@@ -307,7 +330,7 @@ My = M \y \ \D \o \m \e \s \t \i \c = `My Domestic`
 	Hello \ My \ `World` \! = `Hello My Domestic World!`
 	`Hello` \!\ My World \! = `Hello! My Domestic World!`
 
-`Strings containing '\' backslashes can be defined. Note that it's not an escape sequence.`
+`Strings containing `\ backslashes can be defined. Note that it's not an escape sequence.`
 
 `The definition of a string containing 'back_quort' treats 'back_quort' as a character and handles it with string concatenation (coproduct).`
 
@@ -318,8 +341,9 @@ My = M \y \ \D \o \m \e \s \t \i \c = `My Domestic`
 `If you want to include newlines.`
 
 HWinEnter :
- `Hello` \
- `World!`
+ `Hello` \
+ `World!`
+
 
 `"#" becomes the export prefix operator.`
 `Regular functions always return the value of the last line, and match_case returns a value or function corresponding to the specified value.`
@@ -327,6 +351,7 @@ HWinEnter :
 
 #myDict : name value ? name~ : value
 #gets : name ? myDict ' name~
+
 
 `Logical operators are short-circuited.`
 

--- a/documents/en-us/specification/A_Operator_Table.md
+++ b/documents/en-us/specification/A_Operator_Table.md
@@ -1,9 +1,16 @@
 # Sign Language Operator Symbol Table (Priority Order)
 
 ## Basic Principles
+- Prefix operators must be placed immediately before the target value (must not be separated from the target value by spaces)
+- Postfix operators must be placed immediately after the target value (must not be separated from the target value by spaces)
+- Infix operators must be placed between target values and separated by spaces
 - Expression using only operators without reserved words
 - Alignment between natural meaning of symbols and operational meaning
 - Arranged from lowest priority (evaluated later) to highest priority
+- Coproduct operators can be considered as simple delimiters, and all spaces can be regarded as coproduct operators
+- The reason spaces can be regarded as delimiters is that the priority with product operators can be appropriately determined in subsequent processing
+- Line breaks can also be considered as operators, in which case their function has the meaning of evaluation on a line-by-line basis
+- The meaning of line breaks can be replaced with either `|`, `,`, or ` ` (space)
 
 ## Complete Operator List
 
@@ -12,11 +19,11 @@
 | 1 | `#` | prefix | export | Hashtag (public/discoverable) | Make name discoverable from outside |
 | 2 | `:` | infixR | define | That is (identification) | Bind left-hand name to right-hand value |
 | 3 | `#` | infix | output | Hashtag (association) | Associate data with address |
-| 4 | ` ` | infix | push | Coproduct (concatenation) | Add to list |
-| 4 | ` ` | infix | concat | Coproduct (concatenation) | List concatenation |
-| 4 | ` ` | infix | construct | Coproduct (concatenation) | Left-associative list construction |
-| 5 | ` ` | infix | apply | Coproduct (concatenation) | Function application |
-| 6 | ` ` | infix | compose | Coproduct (concatenation) | Left-associative function composition |
+| 4 | ` ` | infix | apply | Coproduct (concatenation) | Function application |
+| 5 | ` ` | infix | compose | Coproduct (concatenation) | Left-associative function composition |
+| 6 | ` ` | infix | push | Coproduct (concatenation) | Add to list |
+| 6 | ` ` | infix | concat | Coproduct (concatenation) | List concatenation |
+| 6 | ` ` | infix | construct | Coproduct (concatenation) | Left-associative list construction |
 | 7 | `?` | infixR | lambda | Question (what to do?) | Function definition |
 | 8 | `,` | infixR | product | Product (structural assembly) | List construction |
 | 9 |  `~` | infix | range | Around (range vicinity) | Range list construction |
@@ -52,6 +59,8 @@
 | 25 | `\t` | prefix | indent | Indent | Indented block construction |
 
 ※Conditional branching is only represented by match_case expressions using function block syntax.
+※When you want to perform function composition with right associativity, use parentheses to make it explicit.
+
 
 ## Special Symbols
 

--- a/documents/en-us/specification/Pure_Functional_Guidelines_en-us.md
+++ b/documents/en-us/specification/Pure_Functional_Guidelines_en-us.md
@@ -66,11 +66,8 @@ classify : x ?
 
 #### Pattern B: Pure general processing only
 ```sign
-` ✅ Valid: Block with general processing only (automatically converted to list)
-process_steps : data ?
-	step1 data
-	step2 result
-	step3 final
+` ✅ Valid: General processing only
+process_steps : data ? step1 step2 step3 data
 ```
 
 #### Pattern C: Proper hierarchical mixing (reference example)
@@ -182,22 +179,6 @@ helper_data : precomputed_expensive_operation
 process_function : input ?
 	transform input config_value helper_data
 ```
-
-### 5.2 Considerations for Use
-
-**However, please keep in mind that this goes against fundamental functional programming principles.**
-
-- **Introduction of global state**: File scope variables are essentially global variables
-- **Testing difficulties**: Unit testing becomes complex due to dependency on external state
-- **Parallel execution constraints**: Risk of race conditions due to shared state
-
-### 5.3 Appropriate Use Cases
-
-Consider file scope only in the following cases:
-
-- Configuration values or configurations
-- Constants that require computationally expensive initialization
-- Immutable data shared across the entire program
 
 ## 6. Avoiding get Operator Dependency
 

--- a/documents/en-us/specification/Type_System_en-us.md
+++ b/documents/en-us/specification/Type_System_en-us.md
@@ -2,19 +2,19 @@
 
 ## 1. The Essence of "Invisible Strong Static Typing"
 
-Sign language realizes the seemingly contradictory characteristic of being "strongly statically typed yet typeless." This is an innovative approach in language design:
+Sign language's type system adopts a different approach from conventional programming languages. In particular, the concept of "invisible strong static typing" aims to ensure type safety without making programmers conscious of the existence of types.
+The essence of this type is guaranteed as follows:
 
-- **Strong static typing aspect**: All values have clear types, and type mismatches are detected at compile time
-- **Typeless aspect**: Programmers do not need to explicitly declare types and can code without being conscious of types
-
-This duality is realized through a "list-based unified data model." Since all computational objects are unified under the concept of lists, the existence of types is not made apparent on the surface.
+- **Name = Type**: The name of an identifier itself expresses the type, making explicit type declarations unnecessary
+- **Value = Type**: Values themselves have types, and type mismatches are detected at compile time
+- **Syntax = Type**: The language syntax guarantees types, allowing programmers to code without being conscious of types
 
 ## 2. List-Based Unified Data Model
 
 Sign language's type system is built around the unified concept of lists:
 
 - **Strings** = List of characters ("lists of characters are treated as strings")
-- **Boolean evaluation** = Pattern matching of values ("empty lists and unexecuted lambda terms are false")
+- **Boolean evaluation** = Pattern matching of values ("empty lists and unevaluated lambda terms are false")
 - **Functions** = List of operations, or functionalization of operators
 - **Collections** = List of values, or list of key-value pairs
 
@@ -38,8 +38,8 @@ Comparison operations in Sign language have the characteristic of returning conc
 ### 4.1 Basic Principle
 
 - When a comparison condition evaluates to `true`, the comparison operation returns **the value of the variable term**
-  - Usually the value of the right side (especially variables) is returned
-  - When the right side is a constant literal, the variable value on the left side is returned
+  - Usually the value of the left side (especially variables) is returned
+  - When the left side is a constant literal, the variable value on the right side is returned
   - Essentially, it returns the variable that is "meaningful as a value" in the comparison
 - When a comparison condition evaluates to `false`, the comparison operation returns **Unit (`_`)**
 - This mechanism allows conditional branching to be treated directly as values without boolean conversion

--- a/documents/en-us/specification/Unit_Specification_en-us.md
+++ b/documents/en-us/specification/Unit_Specification_en-us.md
@@ -1,332 +1,267 @@
-# Sign Language Unit (`_`) Specification
+# Sign Language Unit (`_`) Specification: Bialgebraic Foundation
 
 ## 1. Introduction
 
-The Unit value (`_`) in Sign language is a core concept that forms the foundation of the language design, possessing mathematically consistent properties. This document provides comprehensive coverage from theoretical foundations to implementation details of Unit.
+The Unit value (`_`) in Sign language is a core concept that forms the foundation of the language design, possessing mathematically consistent properties as the unit element of bialgebra. This document provides comprehensive coverage from the category-theoretic foundation to implementation details of Unit.
 
-## 2. Mathematical Foundations of Unit
+## 2. Mathematical Foundation as Bialgebra
 
 ### 2.1 Basic Properties
 
+- **Unit element of bialgebra**: Unit element of both list structure (coalgebra) and function composition (algebra)
 - **Value property**: `_ = []` (equivalent to empty list)
-- **Left identity**: `_ X = X` (applying Unit from the left returns the argument unchanged)
-- **Function identity**: `F _ = F` (in arithmetic and logical categories, passing Unit as an argument returns the function itself)
-- **Duality**: Functions as both a value and a function simultaneously
-- **Logical evaluation**: `_` evaluates to false
-- **Address**: `$_ = 0x0` (Unit's address value is 0)
-- **Input**: `@_ = _` (absorbing element behavior)
-- **Output**: `$_ # X` behaves like file movement to /dev/null
+- **Function property**: Functions as identity morphism
+- **Logical evaluation**: `_` evaluates to false (incidental property)
+- **Important distinction**: `_ ≠ 0` (clearly different from numeric zero)
 
-### 2.2 Category-Theoretic Background
+### 2.2 Definition of Bialgebraic Structure
 
-In category theory, Unit plays the role of identity morphism and natural transformation:
+The list structure in Sign language forms a bialgebra `(List, unit, join, extract, duplicate)`:
 
-- **Identity morphism**: Functions as `_ : X → X`
-- **Natural transformation**: Neutral transformation in function composition
-- **Partial application transformer**: Unit position indicates order transformation
+**Algebraic structure (Monad)**:
+- `unit : A → List A` where `unit(x) = [x]`
+- `join : List(List A) → List A` where `join([[a₁, a₂], [b₁, b₂]]) = [a₁, a₂, b₁, b₂]`
+
+**Coalgebraic structure (Comonad)**:
+- `extract : List A → A` where `extract([x]) = x`, `extract([]) = _`
+- `duplicate : List A → List(List A)` where `duplicate([a, b]) = [[a], [b]]`, `duplicate([]) = [[]]`
+
+### 2.3 Category-Theoretic Proof: `_` as Bialgebraic Unit Element
+
+**Theorem**: `_` is the unit element of bialgebra `(List, unit, join, extract, duplicate)`
+
+**Proof**:
+
+#### Proof of Monad Unit Element
+```
+_ >>= f = f(_) = f([])     // left unit law
+m >>= (\x → _) = _         // right unit law
+
+Examples:
+_ >>= [+ 2] = [+ 2](_) = [+ 2]
+[1,2,3] >>= (\x → _) = _
+```
+
+#### Proof of Comonad Unit Element
+```
+extract(_) = extract([]) = _           // extraction law
+duplicate(_) = duplicate([]) = [[]] = [_]   // duplication law
+```
+
+#### Verification of Bialgebraic Compatibility Conditions
+```
+extract ∘ unit = id:
+extract(unit(_)) = extract([_]) = _ = id(_) ✓
+
+duplicate ∘ unit = unit ∘ unit:
+duplicate(unit(_)) = duplicate([_]) = [[_]]
+unit(unit(_)) = unit([_]) = [[_]] ✓
+```
 
 ## 3. Complete Specification of Unit Operations
 
-### 3.1 Interaction Between Logical Operators and Unit
+### 3.1 Operations in Function Context
 
-Logical operators are based on short-circuit evaluation, and their interaction with Unit is defined as follows:
-
-#### 3.1.1 Logical AND (`&`)
-
+#### 3.1.1 Interaction with Arithmetic Operators
 ```
-` If Unit is the left operand, return Unit (_) (short-circuit evaluation)
-_ & X
-`→ _
+`Generate partial application as unit element of functions
+_ + X → [+ X]
+X + _ → [X +]
 
-` If Unit is the right operand, return Unit (_) (evaluate up to right operand)
-X & _
-`→ _
-
-` If left operand is true, return the value of the right operand
-true_value & X
-`→ X
+`Similarly for other operators
+_ - X → [- X]    X - _ → [X -]
+_ * X → [* X]    X * _ → [X *]
+_ / X → [/ X]    X / _ → [X /]
+_ % X → [% X]    X % _ → [X %]
+_ ^ X → [^ X]    X ^ _ → [X ^]
 ```
 
-#### 3.1.2 Logical OR (`|`)
-
+#### 3.1.2 Interaction with Comparison Operators
 ```
-` If Unit is the left operand, evaluate the right operand
-_ | X
-`→ X
-
-` If left operand is true, return the left operand (short-circuit evaluation)
-X | _
-`→ X
-
-` If left operand is false, evaluate the right operand
-false_value | X
-`→ X
+`Generate comparison functions as unit element of functions
+_ < X → [< X]    X < _ → [X <]
+_ <= X → [<= X]  X <= _ → [X <=]
+_ = X → [= X]    X = _ → [X =]
+_ >= X → [>= X]  X >= _ → [X >=]
+_ > X → [> X]    X > _ → [X >]
+_ != X → [!= X]  X != _ → [X !=]
 ```
 
-#### 3.1.3 Exclusive OR (`;`)
-
+#### 3.1.3 Function Application
 ```
-` Exclusive OR with Unit always returns the other value
-_ ; X
-`→ X
+`Functions as identity morphism
+_ X → [X]
 
-` Exclusive OR with Unit always returns the other value
-X ; _
-`→ X
+`Returns identity morphism when applied to function
+F _ → F
 ```
 
-#### 3.1.4 Negation (`!`)
+### 3.2 Operations in List Context
 
+#### 3.2.1 List Concatenation
 ```
-` Negation of Unit (treated as false) returns a non-Unit value (treated as true)
-!_
-```
+`Unit element as empty list
+_ [X] → [X]
+[X] _ → [X]
 
-### 3.2 Interaction Between Arithmetic/Comparison Operators and Unit
-
-In interactions with operators other than Unit, partially applied lambda expressions are returned:
-
-#### 3.2.1 Arithmetic Operators (`+`, `-`, `*`, `/`, `%`, `^`)
-
-```
-` "If Unit is replaced, add X" lambda is returned
-_ + X
-` →[y ? y + X]
-
-` "If Unit is replaced, add to X" lambda is returned
-X + _
-` →[y ? X + y]
+`Explicit arithmetic operations between lists result in type error
+[_] + [X] → TypeError
+[A] * [B] → TypeError
 ```
 
-Similarly:
+#### 3.2.2 List Operations
 ```
-_ - X
-` → [y ? y - X]
-X - _
-` → [y ? X - y]
-_ * X
-` → [y ? y * X]
-X * _
-` → [y ? X * y]
-_ / X
-` → [y ? y / X]
-X / _
-` → [y ? X / y]
-_ % X
-` → [y ? y % X]
-X % _
-` → [y ? X % y]
-_ ^ X
-` → [y ? y ^ X]
-X ^ _
-` → [y ? X ^ y]
+`Map of empty list is empty list
+map f _ → _
+
+`Fold of empty list is initial value
+fold f init _ → init
 ```
 
-#### 3.2.2 Comparison Operators (`<`, `<=`, `=`, `>=`, `>`, `!=`)
+### 3.3 Operations in Logical Context
 
+In logical operations, incidentally functions as `false`:
+
+#### 3.3.1 Logical AND (`&`)
 ```
-` "If Unit is replaced, compare with <X" lambda is returned
-_ < X
-` → [y ? y < X]  
-
-` "If Unit is replaced, compare X<" lambda is returned
-X < _
-` → [y ? X < y]
+_ & X → _    `short-circuit evaluation
+X & _ → _    `evaluate up to right operand
 ```
 
-Similarly:
+#### 3.3.2 Logical OR (`|`)
 ```
-_ <= X
-` → [y ? y <= X]
-X <= _
-` → [y ? X <= y]
-_ = X
-` → [y ? y = X]
-X = _
-` → [y ? X = y]
-_ >= X
-` → [y ? y >= X]
-X >= _
-` → [y ? X >= y]
-_ > X
-` → [y ? y > X]
-X > _
-` → [y ? X > y]
-_ != X
-` → [y ? y != X]
-X != _
-` → [y ? X != y]
+_ | X → X    `evaluate right operand since left operand is false
+X | _ → X    `short-circuit evaluation if left operand is true
 ```
 
-### 3.3 Interaction Between Function Application and Unit
-
+#### 3.3.3 Exclusive OR (`;`)
 ```
-` Unit behaves as left identity
-_ X
-` → X
-
-` Applying Unit to a function returns the function itself
-F _
-` → F
+_ ; X → X
+X ; _ → X
 ```
 
-## 4. Optimal Implementation on ARM64
+#### 3.3.4 Negation (`!`)
+```
+!_ → true equivalent
+```
 
-### 4.1 Unit Value Representation
+### 3.4 Address/Input-Output Operations
 
-- **Dedicated xZR usage**: Use xZR as Unit representation register (always holds zero)
-- **Callee-saved**: Maintain consistency across functions
+```
+`Reference to Unit itself
+$_ → _
 
-### 4.2 Empty Stack Processing Using Conditional Instructions
+`Input from Unit is absorbed
+@_ → _
+
+`Output to Unit is nullified (/dev/null equivalent)
+_ # X → _
+```
+
+## 4. Distributive Laws of Bialgebra
+
+The functionalization of operators in Sign language is expressed as distributive laws of bialgebra:
+
+```
+`Distributive law: (f ⊗ g)(unit(x)) = unit(f(x)) ⊗ unit(g(x))
+(+ ⊗ *)(unit(x)) = unit(+(x)) ⊗ unit(*(x))
+
+Examples:
+_ + 3 → [+ 3]    `generates unit(+(3))
+_ * 5 → [* 5]    `generates unit(*(5))
+```
+
+This distributive law derives natural functionalization and partial application of operators from the bialgebraic structure.
+
+## 5. Optimal Implementation on ARM64
+
+### 5.1 Unit Value Representation
+
+- **NULL pointer usage**: Represent Unit value as NULL pointer
+- **Conditional instruction utilization**: Optimize Unit judgment with AArch64 conditional instructions
+- **Register optimization**: Utilize characteristics of xZR register
+
+### 5.2 Bialgebraic Operation Optimization
 
 ```assembly
-// Efficient empty stack POP using conditional instructions
-cmp sp, xZR              // Check stack boundary
-csel x0, xZR, x0, eq     // If empty, Unit; otherwise stack value
-cbnz sp, .pop_value      // Branch only if actual POP operation is needed
-.continue:
-// Continue processing
+// Implementation example of _ + X
+cmp x0, #0               // Unit judgment
+b.eq .generate_partial   // Generate partial application if Unit
+// Normal addition processing
 
-.pop_value:
-ldr x0, [sp], #8         // Actual POP operation
-b .continue
-```
-
-### 4.3 Efficient Processing of Unit Functions (Empty Function Pointers)
-
-```assembly
-// Function pointer processing using conditional instructions
-cmp x9, #0               // Check if function pointer is NULL
-csel x16, x30, x9, eq    // If NULL, x30 (link register); otherwise function pointer
-blr x16                  // Conditional call (essentially NOP if NULL)
-```
-
-### 4.4 Implementation of Partial Application and Order Transformation
-
-```assembly
-// Compilation result of myFunc _ 4 (order transformation)
-// 1. Capture fixed argument
-mov w8, #4               // Load fixed argument (4)
-str w8, [x28]            // Save to closure environment
-
-// 2. Generate transformed function
-adr x9, .Ltransformed    // Address of transformed function
-mov x0, x9               // Set function pointer as return value
-ret
-
-// 3. Implementation of transformed function
-.Ltransformed:
-ldr w1, [x28]            // Get fixed argument (4)
-mov w9, w0               // Save newly provided argument
-mov w0, w9               // Set as first argument (order transformation)
-bl myFunc                // Call original function
+.generate_partial:
+adr x1, .add_closure     // Address of [+ X] closure
+mov x0, x1               // Return function pointer
 ret
 ```
 
-### 4.5 Optimization Benefits of Conditional Instructions
+### 5.3 Optimization Using Conditional Instructions
 
-1. **Avoiding branch misprediction**: Prevents pipeline stalls
-2. **Instruction count reduction**: More efficient execution paths
-3. **Instruction-level parallelism**: Can execute in parallel with other instructions
-4. **Efficiency on modern processors**: High performance on latest ARM64 processors
-
-### 4.6 Optimization Patterns
-
-- **Conditional selection (CSEL)**: Optimal for Unit/value selection
-- **Conditional increment (CINC)**: Counter operation optimization
-- **Conditional set (CSET)**: Flag-based computation optimization
-- **Conditional data processing (CCMP)**: Efficient handling of compound conditions
-
-## 5. Practical Examples and Applications
-
-### 5.1 Conditional Branching Using Unit
-
-```sign
-` Return x if x is positive, otherwise return Unit
-isPositive : x ? x > 0
-
-` Usage examples
-` Returns "negative or zero"
-result : isPositive -5 | `negative or zero`
-
-` Returns 10
-result : isPositive 10 | `negative or zero`
+```assembly
+// Integration of Unit judgment and processing
+cmp x0, #0               // Unit judgment
+csel x1, xZR, x0, eq     // xZR if Unit, x0 otherwise
+cbnz x1, .normal_process // Normal processing
+// Unit-specific processing
 ```
 
-### 5.2 Partial Application Using Unit
+## 6. Practical Examples and Applications
+
+### 6.1 Function Composition Utilizing Bialgebraic Properties
 
 ```sign
-add : x y ? x + y
-` Lambda that waits for something to be input to y
-addSomething : add _
+`Bialgebraic representation of map operation
+map_double : [* 2,]
+result : map_double [1, 2, 3, 4]  `→ [2, 4, 6, 8]
 
-` Usage examples
-` Result is "add 5" function
-addFive : addSomething 5
-` Result is 8
-addFive 3
+`Chain of partial applications
+
+`Function composition
+add_then_multiply : [+] [* 2]
+
+result : add_then_multiply 3 5  `→ (5 + 3) * 2 = 16
 ```
 
-### 5.3 Argument Order Transformation
+### 6.2 Conditional Branching Using Unit
 
 ```sign
-` Example of order transformation through partial application
-myFunc : x y z ? x * y + z
+`Utilizing logical properties of Unit
+safe_divide : x y ?
+    y = 0 & _ | [x / y]
 
-` Specifying _ in the 2nd argument position transforms argument order
-partialFunc : myFunc _ 4 7  `Fix y=4, z=7
-
-` On call: partialFunc 3 is equivalent to myFunc 3 4 7
-result : partialFunc 3  `Result is 3 * 4 + 7 = 19
+result : safe_divide 10 0   `→ _ (Unit)
+result : safe_divide 10 2   `→ [5] (result list)
 ```
 
-## 6. Handling Unevaluated Lambdas
-
-### 6.1 Evaluation in Logical Context
-
-- Unexecuted lambda terms evaluate to false
-- In other contexts, they are treated as normal lambdas
-
-### 6.2 Function Existence Checking
+### 6.3 Natural Transformation of Bialgebra
 
 ```sign
-` Existence check using address operator
-$func & `exists` | `does not exist`
+`Unit as natural transformation
+natural_transform : f list ?
+    f _ ` list  `processing for empty case
+    f list      `normal processing
+
+example : natural_transform [* 2,] 1, 2, 3
 ```
 
-### 6.3 Type Checking
+## 7. Design Principles and Theoretical Significance
 
-```sign
-` Function determination through type checking
-"f" = "?" & `is a function` | `is not a function`
-```
+### 7.1 Consistency as Bialgebraic Unit Element
 
-## 7. Compiler Static Optimization Strategies
+1. **Algebraic consistency**: Unit element of function composition satisfying monad laws
+2. **Coalgebraic consistency**: Unit element of list structure satisfying comonad laws
+3. **Bialgebraic compatibility**: Preserves interaction between algebra and coalgebra
+4. **Natural transformation property**: Provides natural transformation between functions and lists
 
-1. **Flow analysis**: Static tracking of stack state and function pointer state
-2. **Redundant check elimination**: Remove checks when state is statically known
-3. **Inlining**: Inline expansion of small functions or Unit functions
-4. **Loop optimization**: Loop conversion of recursive functions
-5. **Register allocation**: Efficient management of Unit-dedicated and general registers
+### 7.2 Integration with Implementation Efficiency
 
-## 8. Design Principles
+- **Theoretical purity**: Design based on deep mathematical foundation
+- **Implementation efficiency**: Highly efficient machine code generation on ARM64
+- **Type safety**: Compile-time verification of bialgebraic structure
+- **Optimization capability**: Automatic optimization utilizing bialgebraic properties
 
-The Unit operation design in Sign language is based on the following principles:
+## 8. Conclusion
 
-1. **Consistency**: Unit provides a consistent way to represent "no value yet" or "invalid value"
-2. **Natural short-circuit evaluation**: Provides semantically correct short-circuit evaluation in logical operations
-3. **Partial application extension**: Extends the partial application mechanism by returning lambdas even for arithmetic and comparison operators
-4. **Error avoidance**: Enables flexible programming by returning Unit or lambdas rather than generating runtime errors
+The Unit (`_`) in Sign language is not merely a "convenient symbol" but a foundational language element with deep mathematical structure as the unit element of bialgebra. By functioning as the unit element of both monads and comonads, it enables unified representation of functional programming and list processing, providing the theoretical foundation for "invisible strong typing" and "zero-cost abstraction".
 
-## 9. Integration of Theory and Implementation
-
-The Unit design in Sign language brilliantly integrates deep mathematical foundations with efficient implementation:
-
-- **Category-theoretic foundation**: Unit concept functions as identity morphism and natural transformation
-- **Functional paradigm**: Partial application and composition are naturally expressed
-- **Exception-free design**: All operations have mathematically consistent results
-- **Execution efficiency**: Maintains theoretical beauty while enabling highly efficient code generation
-
-Sign language achieves both theoretical purity and practical efficiency through the concepts of "invisible strong typing" and "Unit". By leveraging ARM64 architecture's conditional instructions, Unit processing—a core feature of Sign language—can be maximally optimized.
-
-This implementation approach gives Sign language tremendous potential as a language that is not only theoretically beautiful but also operates with high efficiency in actual computing environments.
+This bialgebraic design realizes Sign language as theoretically beautiful, implementation-efficient, and intuitively accessible to programmers.


### PR DESCRIPTION
日本語版ドキュメント更新分の、英語版修正を行いました。

備考：
①Unit_Specification_en-us.mdとUnit_Specification_ja-jp.mdで英語版の更新が新しいものの、
日本語版で追加された部分が多く反映されていなかったため、文書全体を再度翻訳しました。
そのため差分が多くなっています。

②Parse_Strategy_ja-jp.mdは英語版未作成ですが、現在の実装に沿って変更予定なので、日本語版Fix後の対応とします。

③他は英語版更新後の日本語版差分を確認しながら修正。行数ずれは空行追加して合わせています。