### PR TITLE
add:ph4_5 tmp update:ph5-6

### DIFF
--- a/proto/sign_compiler_ver2/project/main_tmp.js
+++ b/proto/sign_compiler_ver2/project/main_tmp.js
@@ -1,0 +1,104 @@
+// main_tmp.js
+// Sign言語パーサーのメイン処理
+// 特定のphaseのみ使用した暫定版
+
+const fs = require('fs');
+const path = require('path');
+
+// Phase1-6のインポート
+const { phase1 } = require('./phases/phase1.js');
+const { phase2 } = require('./phases/phase2.js');
+const { phase3 } = require('./phases/phase3.js');
+const { phase4 } = require('./phases/phase4.js');
+const { phase4_5 } = require('./phases/phase4_5.js');
+const { phase5 } = require('./phases/phase5.js');
+const { phase6 } = require('./phases/phase6.js');
+
+/**
+ * ファイルを読み込む
+ * @param {string} filePath - ファイルパス
+ * @returns {string} - ファイルの内容
+ */
+function readFile(filePath) {
+    try {
+        return fs.readFileSync(filePath, 'utf8');
+    } catch (error) {
+        console.error(`ファイルの読み込みエラー: ${filePath}`, error.message);
+        process.exit(1);
+    }
+}
+
+/**
+ * ファイルに書き込む
+ * @param {string} filePath - ファイルパス
+ * @param {string} content - 書き込む内容
+ */
+function writeFile(filePath, content) {
+    try {
+        // ディレクトリが存在しない場合は作成
+        const dir = path.dirname(filePath);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+
+        fs.writeFileSync(filePath, content, 'utf8');
+        console.log(`結果を保存しました: ${filePath}`);
+    } catch (error) {
+        console.error(`ファイルの書き込みエラー: ${filePath}`, error.message);
+    }
+}
+
+/**
+ * メイン処理
+ */
+function main_tmp() {
+    console.log('Sign言語パーサーを開始します...');
+
+    // 入力ファイルの読み込み
+    const inputPath = './input/testcode_tmp.sn';
+    const inputContent = readFile(inputPath);
+
+    console.log('入力ファイル読み込み完了:', inputPath);
+    console.log('='.repeat(50));
+
+    // Phase1: コメントを削除、改行コードとカッコの統一
+    console.log('Phase1: コメントを削除、改行コードとカッコの統一 を実行中...');
+    const phase1Result = phase1(inputContent);
+
+    // Phase2: 絶対値囲みの前後にカッコ付けを行う
+
+    // Phase3: ブロック構文を判定し、カッコ付けを行う
+    
+    // Phase4: 改行コード統一後、文字列と文字トークンにカッコ付け処理
+    console.log('Phase4: 改行コード統一後、文字列と文字トークンにカッコ付け処理 を実行中...');
+    const phase4Result = phase4(phase1Result);
+
+    // Phase4_5: リストにカッコ付け処理
+    console.log('Phase4_5: リストにカッコ付け処理 を実行中...');
+    const phase4_5Result = phase4_5(phase4Result);
+
+    // Phase4_5の結果をファイルに保存
+    writeFile('./output/phase4_5_result_tmp.sn', phase4_5Result);
+
+    // Phase5: 多項式を二項演算の組・前置記法に変換
+    console.log('Phase5: 多項式を二項演算の組・前置記法に変換 を実行中...');
+    const phase5Result = phase5(phase4_5Result);
+
+    // Phase5の結果をファイルに保存
+    writeFile('./output/phase5_result_tmp.sn', phase5Result);
+
+    // Phase6: 単項演算子（前置・後置）をラムダ記法に変換
+    console.log('Phase6: 単項演算子（前置・後置）をラムダ記法に変換 を実行中...');
+    const phase6Result = phase6(phase5Result);
+
+    // Phase6の結果をファイルに保存
+    writeFile('./output/phase6_result_tmp.sn', phase6Result);
+
+}
+
+// スクリプトが直接実行された場合にメイン処理を実行
+if (require.main === module) {
+    main_tmp();
+}
+
+module.exports = { main_tmp };

--- a/proto/sign_compiler_ver2/project/phases/phase4_5.js
+++ b/proto/sign_compiler_ver2/project/phases/phase4_5.js
@@ -1,0 +1,240 @@
+// phases/phase4_5.js
+// Phase4_5: 空白区切りのリストをカッコで囲う処理
+
+/**
+ * 空白区切りで演算子を含まないトークン列を [...]で囲み、明示的なリスト構造にする
+ * @param {string} input - Phase4_5で処理されるコード
+ * @returns {string} - リスト化処理されたコード
+ */
+function phase4_5(input) {
+    // =================================================================
+    // 文字・文字列保護による前処理
+    // =================================================================
+    
+    const protection = protectLiterals(input);
+    const protectedInput = protection.protectedText;
+    const charMap = protection.charMap;
+    const stringMap = protection.stringMap;
+
+    console.log('保護処理後:', protectedInput);
+
+    // =================================================================
+    // 真の文境界での分割と処理
+    // =================================================================
+
+    // 保護処理後の文字列で改行分割（この時点で残っている改行は真の文境界）
+    const lines = protectedInput.split(/\r?\n/);
+    
+    const processedLines = lines.map(line => {
+        // 空行やコメント行はそのまま
+        if (!line.trim()) return line;
+        if (line.trim().startsWith('`')) return line;
+
+        // インデントを保持
+        const indent = line.match(/^[\t ]*/)[0];
+        const content = line.substring(indent.length);
+
+        // 既にカッコで囲まれている場合はそのまま
+        if (content.match(/^\s*[\[\{\(].*[\]\}\)]\s*$/)) {
+            console.log(`既にカッコで囲まれている、スキップ: ${line}`);
+            return line;
+        }
+
+        // トークン化（phase5から流用）
+        const tokens = tokenize(content);
+        console.log('トークン化結果:', tokens);
+
+        // 単一トークンまたは空の場合はそのまま
+        if (tokens.length <= 1) return line;
+
+        // 連続する識別子（非演算子）を検出してリスト化
+        const resultTokens = [];
+        let consecutiveIdentifiers = [];
+
+        for (const token of tokens) {
+            if (!isOperator(token)) {
+                // 識別子の場合、連続区間に追加
+                consecutiveIdentifiers.push(token);
+            } else {
+                // 演算子の場合、これまでの連続区間を処理
+                if (consecutiveIdentifiers.length >= 2) {
+                    const listExpression = `{${consecutiveIdentifiers.join(' ')}}`;
+                    resultTokens.push(listExpression);
+                    console.log(`連続識別子をリスト化: ${consecutiveIdentifiers.join(' ')} → ${listExpression}`);
+                } else if (consecutiveIdentifiers.length === 1) {
+                    resultTokens.push(consecutiveIdentifiers[0]);
+                }
+                consecutiveIdentifiers = [];
+                resultTokens.push(token);
+            }
+        }
+
+        // 最後の連続区間も処理
+        if (consecutiveIdentifiers.length >= 2) {
+            const listExpression = `{${consecutiveIdentifiers.join(' ')}}`;
+            resultTokens.push(listExpression);
+            console.log(`最後の連続識別子をリスト化: ${consecutiveIdentifiers.join(' ')} → ${listExpression}`);
+        } else if (consecutiveIdentifiers.length === 1) {
+            resultTokens.push(consecutiveIdentifiers[0]);
+        }
+
+        // 変換済みトークンを結合
+        const finalExpression = resultTokens.join(' ');
+        console.log(`最終結果: ${content} → ${finalExpression}`);
+        return indent + finalExpression;
+    });
+
+    // 処理済みの行を改行で再結合
+    let result = processedLines.join('\n');
+
+    // =================================================================
+    // 保護解除処理
+    // =================================================================
+
+    result = restoreLiterals(result, charMap, stringMap);
+    console.log('保護解除後:', result);
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// phase5から流用する演算子定義と補助関数
+// ※以下のコードはphase5と同一内容
+///////////////////////////////////////////////////////////////////////////////
+
+// phase5と同じ演算子リスト
+const OperatorList = [
+    { "'": { precedence: 22, associativity: 'left' } },   // get（左単位元）
+    { '@': { precedence: 22, associativity: 'right' } },  // get（右単位元）
+    { '^': { precedence: 17, associativity: 'right' } },  // 冪乗
+    { '*': { precedence: 16, associativity: 'left' } },   // 乗算
+    { '/': { precedence: 16, associativity: 'left' } },   // 除算
+    { '%': { precedence: 16, associativity: 'left' } },   // 剰余
+    { '+': { precedence: 15, associativity: 'left' } },   // 加算
+    { '-': { precedence: 15, associativity: 'left' } },   // 減算
+    { '<': { precedence: 14, associativity: 'left' } },   // より小さい
+    { '<=': { precedence: 14, associativity: 'left' } },  // 以下
+    { '=': { precedence: 14, associativity: 'left' } },   // 等しい
+    { '==': { precedence: 14, associativity: 'left' } },  // 等しい
+    { '>=': { precedence: 14, associativity: 'left' } },  // 以上
+    { '>': { precedence: 14, associativity: 'left' } },   // より大きい
+    { '!=': { precedence: 14, associativity: 'left' } },  // 等しくない
+    { '&': { precedence: 12, associativity: 'left' } },   // 論理積
+    { ';': { precedence: 11, associativity: 'left' } },   // 排他的論理和
+    { '|': { precedence: 11, associativity: 'left' } },   // 論理和
+    { '?': { precedence: 7, associativity: 'right' } },   // ラムダ構築
+    { '#': { precedence: 3, associativity: 'right' } },   // output（中置演算子）
+    { ':': { precedence: 2, associativity: 'right' } },   // 定義
+];
+
+/**
+ * OperatorListから通常の演算子優先順位テーブルを生成
+ * ※phase5と同一の関数
+ * @returns {Object} 演算子をキーとした優先順位・結合性情報のオブジェクト
+ */
+function createPrecedenceTable() {
+    const table = {};
+
+    OperatorList.forEach(operatorObj => {
+        const [operator, info] = Object.entries(operatorObj)[0];
+        table[operator] = info;
+    });
+
+    return table;
+}
+
+/**
+ * 入力文字列を空白で分割してトークン配列を作成
+ * 初期版では純粋な中置記法のみ対応（ブロック構文は後の実装で追加）
+ * ※phase5と同一の関数
+ * @param {string} text - トークン化対象の文字列
+ * @returns {Array} トークンの配列
+ */
+function tokenize(text) {
+    const regex = /\{[^{}]*\}|\[[a-zA-Z0-9_\s,~]+\]|\[`[^`\r\n]*`\]|\[\\[\s\S]\]|\[\||\|\]|[\[\]]|[^ \t\[\]|]+/g;
+    /*
+    正規表現の構成要素:
+     \{[^{}]*\}           - {}で囲まれた部分を一つのトークンとして認識（リスト保護用）
+     \[[a-zA-Z0-9_\s,]+\]| - カッコ内「識別子、空白、コメント、積、中置~のみ」一つのトークンとして認識
+     \[`[^`\r\n]*`\]      - 文字列[``]を個別トークンとして認識
+     \[\\[\s\S]\]         - 文字[\]を個別トークンとして認識
+     \[\|                 - 絶対値開始記号 [| を個別トークンとして認識
+     \|\]                 - 絶対値終了記号 |] を個別トークンとして認識
+     [\[\]]               - 通常のカッコ [ または ] を個別トークンとして認識
+     [^ \t\[\]|]+         - 以下以外の連続する文字をトークンとして認識:
+                             スペース（ ）/タブ（\t）/角カッコ（[ ]）/パイプ（|）
+    注意: より具体的なパターンを先に記述することで、意図しないマッチを防いでいる
+    */
+    return text.match(regex) || [];
+}
+
+/**
+ * 指定されたトークンが演算子かどうかを判定
+ * 演算子優先順位テーブルに存在するかで判定
+ * ※phase5と同一の関数
+ * @param {string} token - 判定対象のトークン
+ * @returns {boolean} 演算子ならtrue、そうでなければfalse
+ */
+function isOperator(token) {
+    const precedenceTable = createPrecedenceTable();
+    return precedenceTable.hasOwnProperty(token);
+}
+
+
+/**
+ * 文字・文字列リテラルを一時的に置換して保護する
+ * @param {string} input - 保護対象の文字列
+ * @returns {Object} 保護処理結果 {protectedText, charMap, stringMap}
+ */
+function protectLiterals(input) {
+    let protectedInput = input;
+    const charMap = [];
+    const stringMap = [];
+    let charIndex = 0;
+    let stringIndex = 0;
+
+    // 1. 文字リテラル（\+任意の1文字）を一時的に置換
+    protectedInput = protectedInput.replace(/\\[\s\S]/g, (match) => {
+        charMap[charIndex] = match;
+        return `__CHAR_${charIndex++}__`;
+    });
+
+    // 2. 文字列リテラル（`...`）を一時的に置換
+    protectedInput = protectedInput.replace(/`[^`\r\n]*`/g, (match) => {
+        stringMap[stringIndex] = match;
+        return `__STRING_${stringIndex++}__`;
+    });
+
+    return {
+        protectedText: protectedInput,
+        charMap: charMap,
+        stringMap: stringMap
+    };
+}
+
+/**
+ * 保護されたリテラルを元に戻す
+ * @param {string} input - 復元対象の文字列
+ * @param {Array} charMap - 文字リテラルのマップ
+ * @param {Array} stringMap - 文字列リテラルのマップ
+ * @returns {string} 復元後の文字列
+ */
+function restoreLiterals(input, charMap, stringMap) {
+    let result = input;
+
+    // 文字トークンを元に戻す
+    result = result.replace(/__CHAR_(\d+)__/g, (match, index) => {
+        return charMap[index] || match;
+    });
+
+    // 文字列トークンを元に戻す
+    result = result.replace(/__STRING_(\d+)__/g, (match, index) => {
+        return stringMap[index] || match;
+    });
+
+    return result;
+}
+
+// テスト実行用（コメントアウト）
+// console.log(phase4_5(require('fs').readFileSync('./input/testcode_tmp.sn', 'utf8')));
+
+module.exports = { phase4_5 };

--- a/proto/sign_compiler_ver2/project/phases/phase6.js
+++ b/proto/sign_compiler_ver2/project/phases/phase6.js
@@ -1,5 +1,5 @@
 // phases/phase6.js
-// Phase6: 単項演算子（前置・後置）をラムダ記法に変換する
+// Phase6: 単項演算子（前置・後置）をラムダ記法に変換し、{}保護を[]に復元する
 
 /**
  * 単項演算子を前置記法に変換
@@ -19,10 +19,12 @@ function phase6(input) {
         .replace(
             /([a-zA-Z0-9_]+|\[[^\]]*\])([!~@])(?=\s|$)/g,
             '[[_$2] $1]'
-        );
+        )
+        // {}保護を[]に復元
+        .replace(/\{([^{}]*)\}/g, '[$1]');
 }
 
 //test実行
-console.log(phase6(require('fs').readFileSync('./input/testcode_tmp.sn', 'utf8')));
+//console.log(phase6(require('fs').readFileSync('./input/testcode_tmp.sn', 'utf8')));
 
 module.exports = { phase6 };


### PR DESCRIPTION
ph4_5:リストカッコ追加処理
ph5のトークン化でリストを1トークン扱いにするため、リストは{}カッコ使用。
※操車場アルゴリズム処理を簡潔にする意図。
ph6最後で{}を[]に変換している。

暫定版として、一部のphを除いたmain_tmpで動作確認。
ブロック化処理、絶対値処理のph修正後、mainで通し実行できるように修正する予定。