### PR TITLE
update : lexer parser

### DIFF
--- a/proto/sign_compiler_ver2/project/input/testcode.sn
+++ b/proto/sign_compiler_ver2/project/input/testcode.sn
@@ -1,5 +1,3 @@
-test1 : !(a = b)
-test2 : (a + b)!
 `文字列と文字のテスト`
 Hello : `Hello World`
 backslash : `Sign\s language`
@@ -45,6 +43,10 @@ char01 : \M
 func1 : [+ 1]
 func2 : (x y ? x + y)
 func3 : {a, b, c} \( \) \{ \} \[ \]
+
+`ブロックの単項演算子テスト`
+test1 : !(a! = !b)
+test2 : (a + b)!
 
 abc | def
 abc d e f

--- a/proto/sign_compiler_ver2/project/lexer.js
+++ b/proto/sign_compiler_ver2/project/lexer.js
@@ -20,10 +20,10 @@
 
 
 const preprocess = code => code
-  .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\xA0\xAD]/g, '')                              
-  .replace(/^`[^\r\n]*(\r\n|[\r\n])/gm, '')                                                   
-  .replace(/([!@$#~]+)([\[\{\(])/g, '$1 $2')           // 前置演算子 + 開きカッコ
-  .replace(/([\]\}\)])([!~@]+)/g, '$1 $2')             // 閉じカッコ + 後置演算子
+  .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F\xA0\xAD]/g, '')
+  .replace(/^`[^\r\n]*(\r\n|[\r\n])/gm, '')
+  .replace(/([!@$#~]+)([\[\{\(])/g, '$1 $2')                      // Prefix operators + opening brackets
+  .replace(/([\]\}\)])([!~@]+)/g, '$1 $2')                        // Closing brackets + postfix operators
   .replace(/([^ ]*)([:?,;&=<>+*/%^']+|!=)([^ ]*)|(\\[\s\S])|(`[^`\n\r]+`)/g, '$1 $2 $3$4$5');
   
 const tokenize = code => code
@@ -58,7 +58,7 @@ const bracketToBlock = tokens =>
               const end = findClose(tokens);
               return { 
                 result: [...result, bracketToBlock(tokens.slice(idx + 1, end))], 
-                skip: end + 1 
+                skip: end
               };
             })()
         : [']'].includes(token) ? { result, skip }


### PR DESCRIPTION
## 概要
update : lexer parser

## 関連Issue
#138 

## 変更内容
- proto\sign_compiler_ver2\project\lexer.js
25-26行目
```javascript
  .replace(/([!@$#~]+)([\[\{\(])/g, '$1 $2')                      // Prefix operators + opening brackets
  .replace(/([\]\}\)])([!~@]+)/g, '$1 $2')                        // Closing brackets + postfix operators
```
→ブロックに対する単項演算子をトークン化（"!["を"!"とブロックに分ける）

61行目
```javascript
                skip: end        // ← end + 1 ではなく end にする
```
→[と]が同じ配列内に存在する場合、[の処理でend + 1までスキップするため、
　]の後のトークンも一緒にスキップされていた。
　+ 1を削除することで、スキップせず後置演算子が残るようになった。
→見落としていた不具合ですが、"\\("がトークンから消えていた現象が解決。


- proto\sign_compiler_ver2\project\parser.js
→単項演算子のブロック対応
→後置演算子でカッコ多くなる部分を修正（前置、二項ではカッコ反映されてないためそのあたりも削除）

- proto\sign_compiler_ver2\project\input\testcode.sn
→ブロックの単項演算子テスト 追加


## 確認事項
- [✅] 動作確認済み