### PR TITLE
update : Operator_table(en)

### DIFF
--- a/documents/en-us/specification/A_Operator_Table.md
+++ b/documents/en-us/specification/A_Operator_Table.md
@@ -27,6 +27,11 @@
 | 6 | ` ` | infix | construct | Coproduct (concatenation) | Left-associative list construction |
 | 7 | `?` | infixR | lambda | Question (what to do?) | Function definition |
 | 8 | `~` | infix | range | Around (range vicinity) | Range list construction |
+| 8 | `~+` | infix | range | Around (range vicinity) | Arithmetic progression specification |
+| 8 | `~-` | infix | range | Around (range vicinity) | Descending arithmetic progression specification |
+| 8 | `~*` | infix | range | Around (range vicinity) | Geometric progression specification |
+| 8 | `~/` | infix | range | Around (range vicinity) | Exponential progression specification |
+| 8 | `~^` | infix | range | Around (range vicinity) | Range list construction |
 | 9 | `~` | prefix | continuous | Around (entire vicinity) | Continuous list construction |
 | 10 | `;` | infix | xor | Exclusive relationship | Exclusive logical OR |
 | 10 | `\|` | infix | or | Or (passage) | Logical OR (short-circuit evaluation) |


### PR DESCRIPTION
## 概要
A_Operator_Table（英語版）の更新

## 関連Issue
なし

## 変更内容
[主な変更点を箇条書き]
- documents\en-us\specification\A_Operator_Table.md
日本語版の追加部分（`~+`から`~^`まで）を反映 da5bde58847f16dbcb3fa799470847172fc03c05